### PR TITLE
fix: main workflow apply access

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -14,7 +14,7 @@ data "google_iam_policy" "github_actions_plan_sa_bindings" {
 data "google_iam_policy" "github_actions_apply_sa_bindings" {
   // Allow the apply identity to act as the service account
   binding {
-    role = "roles/iam.serviceAccountUser"
+    role = "roles/iam.workloadIdentityUser"
 
     members = [local.github_actions_apply_identity]
   }


### PR DESCRIPTION
Closes #5 

> ## Bug behavior
> 
> The GCP auth step in the GitHub Actions workflow shows:
> ```
> Error: google-github-actions/auth failed with: failed to generate Google Cloud OAuth 2.0 Access Token for github-actions-apply@gha-gcp-opentofu-7.iam.gserviceaccount.com: {
>   "error": {
>     "code": 403,
>     "message": "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).",
>     "status": "PERMISSION_DENIED",
>     "details": [
>       {
>         "@type": "type.googleapis.com/google.rpc.ErrorInfo",
>         "reason": "IAM_PERMISSION_DENIED",
>         "domain": "iam.googleapis.com",
>         "metadata": {
>           "permission": "iam.serviceAccounts.getAccessToken"
>         }
>       }
>     ]
>   }
> }
> ```
> 
> ## Expected behavior
> 
> Successful GCP auth when merging to `main`.