### PR TITLE
Post workflow plan output to PR

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -1,0 +1,37 @@
+name: Main workflow
+on:
+  push:
+    branches:
+      - main
+
+env:
+  tofu_version: 1.8.2
+  tg_version: 0.67.10
+  working_dir: .infra/gcp-gha-gcp-opentofu
+
+jobs:
+  apply:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: 'write' # Needed for the google-github-actions/auth step
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+      - id: apply-auth
+        name: GCP auth
+        uses: google-github-actions/auth@v2.1.5
+        with:
+          export_environment_variables: false
+          create_credentials_file: false
+          token_format: access_token
+          workload_identity_provider: projects/918666231212/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+          service_account: github-actions-apply@gha-gcp-opentofu-7.iam.gserviceaccount.com
+      - name: Apply
+        uses: gruntwork-io/terragrunt-action@v2.1.4
+        with:
+          tofu_version: ${{ env.tofu_version }}
+          tg_version: ${{ env.tg_version }}
+          tg_dir: ${{ env.working_dir }}
+          tg_command: 'apply'
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.apply-auth.outputs.access_token }}

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,13 +1,16 @@
-name: Push workflow
-on: [push]
+name: Pull request workflow
+on:
+  pull_request:
+    types:
+      - synchronize
 
 env:
   tofu_version: 1.8.2
   tg_version: 0.67.10
   working_dir: .infra/gcp-gha-gcp-opentofu
 
+# All PR jobs should be listed in required_status_checks https://github.com/rcwbr/gha-gcp-opentofu/blob/1414227daae1579b2c382652e31ca1eba0d18fab/.github/settings.yml#L55
 jobs:
-  # All PR jobs should be listed in required_status_checks https://github.com/rcwbr/gha-gcp-opentofu/blob/1414227daae1579b2c382652e31ca1eba0d18fab/.github/settings.yml#L55
   check-hcl:
     runs-on: ubuntu-24.04
     steps:
@@ -36,6 +39,7 @@ jobs:
     needs: [ check-hcl, check-tf ]
     permissions:
       id-token: 'write' # Needed for the google-github-actions/auth step
+      pull-requests: 'write' # Needed to post plan results comment to PR
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
@@ -54,34 +58,8 @@ jobs:
           tofu_version: ${{ env.tofu_version }}
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
+          tg_comment: 1
           tg_command: plan
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.plan-auth.outputs.access_token }}
-
-  apply:
-    runs-on: ubuntu-24.04
-    if: github.ref == 'refs/heads/main'
-    needs: [ plan ]
-    permissions:
-      id-token: 'write' # Needed for the google-github-actions/auth step
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.7
-      - id: apply-auth
-        name: GCP auth
-        uses: google-github-actions/auth@v2.1.5
-        with:
-          export_environment_variables: false
-          create_credentials_file: false
-          token_format: access_token
-          workload_identity_provider: projects/918666231212/locations/global/workloadIdentityPools/github-actions/providers/github-actions
-          service_account: github-actions-apply@gha-gcp-opentofu-7.iam.gserviceaccount.com
-      - name: Apply
-        uses: gruntwork-io/terragrunt-action@v2.1.4
-        with:
-          tofu_version: ${{ env.tofu_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
-          tg_command: 'apply'
-        env:
-          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.apply-auth.outputs.access_token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #8 

> ## What
> 
> Enable posting of the Terragrunt plan step output from the CI workflow back to the PR as a comment
> 
> ## Why
> 
> To increase convenience of visibility into changes
> 
> ## How
> 
> Leverage the [`tg_comment` input](https://github.com/gruntwork-io/terragrunt-action/tree/main?tab=readme-ov-file#inputs)