### PR TITLE
fix: apply wif identity ref syntax

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@ locals {
   // Identity (for plan permissions) for GitHub Actions from any branch of the repo
   github_actions_plan_identity = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/*"
   // Identity (for apply permissions) for GitHub Actions from only the default branch (https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
-  github_actions_apply_identity = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.ref/${var.github_default_branch_name}"
+  github_actions_apply_identity = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.ref/refs/heads/${var.github_default_branch_name}"
 
   state_bucket_name = var.state_bucket_name != "" ? var.state_bucket_name : "${var.gcp_project}-opentofu-state"
 }


### PR DESCRIPTION
Closes #5 

> ## Bug behavior
> 
> The GCP auth step in the GitHub Actions workflow shows:
> ```
> Error: google-github-actions/auth failed with: failed to generate Google Cloud OAuth 2.0 Access Token for github-actions-apply@gha-gcp-opentofu-7.iam.gserviceaccount.com: {
>   "error": {
>     "code": 403,
>     "message": "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).",
>     "status": "PERMISSION_DENIED",
>     "details": [
>       {
>         "@type": "type.googleapis.com/google.rpc.ErrorInfo",
>         "reason": "IAM_PERMISSION_DENIED",
>         "domain": "iam.googleapis.com",
>         "metadata": {
>           "permission": "iam.serviceAccounts.getAccessToken"
>         }
>       }
>     ]
>   }
> }
> ```
> 
> ## Expected behavior
> 
> Successful GCP auth when merging to `main`.