### PR TITLE
fix: authenticate apply step

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -82,3 +82,5 @@ jobs:
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
           tg_command: 'apply'
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}


### PR DESCRIPTION
Closes #12 

> ## Bug behavior
> 
> Apply jobs for workflow fail with the following error:
> 
> ```
> 14:49:24.103 ERROR  dialing: google: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information
> 14:49:24.104 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
> ```
> 
> ## Expected behavior
> 
> Successful apply