### PR TITLE
ci: leverage tokens with applicable access

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
-      - id: auth
+      - id: plan-auth
         name: GCP auth
         uses: google-github-actions/auth@v2.1.5
         with:
@@ -55,7 +55,7 @@ jobs:
           tg_dir: ${{ env.working_dir }}
           tg_command: plan
         env:
-          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.plan-auth.outputs.access_token }}
 
   apply:
     runs-on: ubuntu-24.04
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
-      - id: auth
+      - id: apply-auth
         name: GCP auth
         uses: google-github-actions/auth@v2.1.5
         with:
@@ -83,4 +83,4 @@ jobs:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'apply'
         env:
-          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.apply-auth.outputs.access_token }}


### PR DESCRIPTION
Closes #14 

> ## Bug behavior
> 
> Permissions denied on many resources, e.g.
> 
> ```
> STDERR tofu: │ Error: Error when reading or editing Resource "project \"gha-gcp-opentofu-7\"" with IAM Member: Role "roles/viewer" Member "serviceAccount:github-actions-plan@gha-gcp-opentofu-7.iam.gserviceaccount.com": Error retrieving IAM policy for project "gha-gcp-opentofu-7": googleapi: Error 403: The caller does not have permission, forbidden
> ```
> 
> See [workflow job](https://github.com/rcwbr/gha-gcp-opentofu/actions/runs/11238185056/job/31242392190#step:5:87)
> 
> ## Expected behavior
> 
> Successful apply