### PR TITLE
fix: grant apply required roles

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -2,8 +2,10 @@ variable "apply_action_project_roles" {
   type = list(string)
   default = [
     "roles/iam.serviceAccountAdmin",
-    "roles/storage.admin",
-    "roles/iam.workloadIdentityPoolAdmin"
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/storage.admin"
   ]
   description = "The list of project-wide roles to grant apply actions"
 }


### PR DESCRIPTION
Closes #14 

> ## Bug behavior
> 
> Permissions denied on many resources, e.g.
> 
> ```
> STDERR tofu: │ Error: Error when reading or editing Resource "project \"gha-gcp-opentofu-7\"" with IAM Member: Role "roles/viewer" Member "serviceAccount:github-actions-plan@gha-gcp-opentofu-7.iam.gserviceaccount.com": Error retrieving IAM policy for project "gha-gcp-opentofu-7": googleapi: Error 403: The caller does not have permission, forbidden
> ```
> 
> See [workflow job](https://github.com/rcwbr/gha-gcp-opentofu/actions/runs/11238185056/job/31242392190#step:5:87)
> 
> ## Expected behavior
> 
> Successful apply