### PR TITLE
14 apply step fails due to permission forbidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The module reads the following variables as input:
 | `gcp_project` | &check; | N/A | The GCP project name |
 | `gcp_region` | &check; | N/A | The GCP region for all resources managed within the project |
 | `github_repo` | &check; | N/A | The fully-qualified name of the GitHub repo to which the state access will be granted |
-| `apply_action_project_roles` | &cross; | `[ "roles/iam.serviceAccountAdmin", "roles/storage.admin", "roles/iam.workloadIdentityPoolAdmin" ]` | The list of project-wide roles to grant apply actions |
+| `apply_action_project_roles` | &cross; | `[ "roles/iam.serviceAccountAdmin", "roles/iam.roleAdmin", "roles/iam.workloadIdentityPoolAdmin", "roles/resourcemanager.projectIamAdmin", "roles/serviceusage.serviceUsageAdmin", "roles/storage.admin" ]` | The list of project-wide roles to grant apply actions |
 | `github_default_branch_name` | &cross; | `"main"` | The default/mainline branch name for the GitHub repo, workflows for which have OpenTofu apply (vs. plan) access |
 | `state_bucket_name` | &cross; | `"${var.gcp_project}-opentofu-state"` | The name of the bucket used for OpenTofu state |
 

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@ variable "apply_action_project_roles" {
   type = list(string)
   default = [
     "roles/iam.serviceAccountAdmin",
+    "roles/iam.roleAdmin",
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/resourcemanager.projectIamAdmin",
     "roles/serviceusage.serviceUsageAdmin",


### PR DESCRIPTION
Closes #14 

> ## Bug behavior
> 
> Permissions denied on many resources, e.g.
> 
> ```
> STDERR tofu: │ Error: Error when reading or editing Resource "project \"gha-gcp-opentofu-7\"" with IAM Member: Role "roles/viewer" Member "serviceAccount:github-actions-plan@gha-gcp-opentofu-7.iam.gserviceaccount.com": Error retrieving IAM policy for project "gha-gcp-opentofu-7": googleapi: Error 403: The caller does not have permission, forbidden
> ```
> 
> See [workflow job](https://github.com/rcwbr/gha-gcp-opentofu/actions/runs/11238185056/job/31242392190#step:5:87)
> 
> ## Expected behavior
> 
> Successful apply