### PR TITLE
fix: grant apply admin over plan account

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -8,6 +8,12 @@ data "google_iam_policy" "github_actions_plan_sa_bindings" {
     role    = "roles/iam.workloadIdentityUser"
     members = [local.github_actions_plan_identity]
   }
+
+  // Allow the apply account to administer the service account
+  binding {
+    role    = "roles/iam.serviceAccountAdmin"
+    members = [google_service_account.github_actions_apply.member]
+  }
 }
 
 data "google_iam_policy" "github_actions_apply_sa_bindings" {


### PR DESCRIPTION
Closes #14 

> ## Bug behavior
> 
> Permissions denied on many resources, e.g.
> 
> ```
> STDERR tofu: │ Error: Error when reading or editing Resource "project \"gha-gcp-opentofu-7\"" with IAM Member: Role "roles/viewer" Member "serviceAccount:github-actions-plan@gha-gcp-opentofu-7.iam.gserviceaccount.com": Error retrieving IAM policy for project "gha-gcp-opentofu-7": googleapi: Error 403: The caller does not have permission, forbidden
> ```
> 
> See [workflow job](https://github.com/rcwbr/gha-gcp-opentofu/actions/runs/11238185056/job/31242392190#step:5:87)
> 
> ## Expected behavior
> 
> Successful apply