### PR TITLE
Prevent PR merge with incomplete jobs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -55,6 +55,10 @@ rulesets:
           required_status_checks:
             - context: check-hcl
               integration_id: 15368 # GitHub Actions integration ID
+            - context: check-tf
+              integration_id: 15368
+            - context: plan
+              integration_id: 15368
           # Requires PR branches to be up-to-date with target
           strict_required_status_checks_policy: true
 

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -7,6 +7,7 @@ env:
   working_dir: .infra/gcp-gha-gcp-opentofu
 
 jobs:
+  # All PR jobs should be listed in required_status_checks https://github.com/rcwbr/gha-gcp-opentofu/blob/1414227daae1579b2c382652e31ca1eba0d18fab/.github/settings.yml#L55
   check-hcl:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Closes #42 

> ## Bug behavior
> 
> PRs become mergeable after success of only the `check-hcl` job.
> 
> <img width="913" alt="Screen Shot 2024-10-13 at 11 58 50" src="https://github.com/user-attachments/assets/f9e46768-1920-495c-8398-60e15c9af2d6">
> 
> ## Expected behavior
> 
> PRs should be blocked until all workflow jobs pass
> 