### PR TITLE
fix: release-it workflow check name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -60,7 +60,7 @@ rulesets:
               integration_id: 15368
             - context: plan
               integration_id: 15368
-            - context: Release-it workflow / Release-it dry-run
+            - context: Release-it workflow / release-it-workflow / Release-it dry-run
               integration_id: 15368
           # Requires PR branches to be up-to-date with target
           strict_required_status_checks_policy: true


### PR DESCRIPTION
Closes #50 

> ## What
> 
> Change PR check requirements to match workflow job names as defined by upstream reusable release-it workflow.
> 
> ## Why
> 
> To enable passing PR checks with the release-it workflow
> 
> ## How
> 
> Probot check settings name change