### PR TITLE
Apply tag protection and bypass configuration settings as code

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,20 +12,23 @@ repository:
   delete_branch_on_merge: true
 
 rulesets:
-  # TODO re-enable tag protection, see https://github.com/rcwbr/gha-gcp-opentofu/issues/45
-  # - name: Tags rules
-  #   target: tag
-  #   enforcement: active
-  #   conditions:
-  #     ref_name:
-  #       include:
-  #         - "~ALL"
-  #       exclude: []
-  #   rules:
-  #     - type: creation
-  #     - type: deletion
-  #     - type: non_fast_forward
-  #     - type: update
+  - name: Tags rules
+    target: tag
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - "~ALL"
+        exclude: []
+    bypass_actors:
+      - actor_id: 1050753 # gha-gcp-opentofu release-it app
+        actor_type: Integration
+        bypass_mode: always
+    rules:
+      - type: creation
+      - type: deletion
+      - type: non_fast_forward
+      - type: update
   - name: Default branch rules
     target: branch
     enforcement: active
@@ -66,3 +69,9 @@ rulesets:
           strict_required_status_checks_policy: true
 
 collaborators: [] # No collaborators defined
+
+environments:
+  - name: Repo release # Must match the app-environment workflow input
+    deployment_branch_policy:
+      custom_branches:
+        - main

--- a/.github/workflows/release-it-workflow.yaml
+++ b/.github/workflows/release-it-workflow.yaml
@@ -2,6 +2,9 @@ name: Release-it workflow
 on: push
 jobs:
   release-it-workflow:
-    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0
-    permissions:
-      contents: write
+    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.2.0
+    with:
+      app-id: 1050753 # gha-gcp-opentofu release-it app
+      app-environment: Repo release
+    secrets:
+      app-secret: ${{ secrets.RELEASE_IT_GITHUB_APP_KEY }} # Secret belonging to the Repo release environment

--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ Initial provisioning of resources to enable infrastructue-as-code automation req
 
 The GitHub repo settings for this repo are defined as code using the [Probot settings GitHub App](https://probot.github.io/apps/settings/). Settings values are defined in the `.github/settings.yml` file. Enabling automation of settings via this file requires installing the app.
 
-### CI/CD in forks
+The settings applied are as recommended in the [release-it-gh-workflow usage](https://github.com/rcwbr/release-it-gh-workflow/blob/4dea4eaf328b60f92dab1b5bd2a63daefa85404b/README.md?plain=1#L58), including tag and branch protections, GitHub App and environment authentication, and required checks.
+
+### CI/CD
+
+This repo uses the [release-it-gh-workflow](https://github.com/rcwbr/release-it-gh-workflow), with the conventional-changelog image defined at any given ref, as its automation.
+
+#### CI/CD in forks
 
 Forks of the repository will not have access to the state bucket via CI/CD, thanks to the [google_iam_workload_identity_pool_provider attribute_condition (defined in `main.tf`)](https://github.com/rcwbr/gha-gcp-opentofu/blob/3b7c801608849ec18ef72225c26f0f57ad84477f/main.tf#L41). Forks should test a `plan` and `apply` (via Actions) against a new project, then open a PR for which CI/CD will fail. Repo contributors may then reconfigure the PR to target an unprotected branch to bring the changes into the repo, from which the final PR to `main` may be opened.


### PR DESCRIPTION
Closes #45 

> ## What
> 
> Track tag protections and bypass settings for release-it application as code
> 
> ## Why
> 
> Establish traceability of settings
> 
> ## How
> 
> Leverage the steps documented by https://github.com/rcwbr/release-it-gh-workflow/issues/8